### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ helm repo add diazoxide https://raw.githubusercontent.com/diazoxide/symfony-helm
 ## Install chart
 Then, install the chart:
 ```shell
-helm upgrade --install symfony diazoxide/symfony-helm --values values.yaml
+helm upgrade --install symfony diazoxide/symfony --values values.yaml
 ```
 
 # Development and contribution


### PR DESCRIPTION
```
helm upgrade --install symfony diazoxide/symfony-helm --values values.yaml

Error: chart "symfony-helm" matching  not found in diazoxide index. (try 'helm repo update'): no chart name found
```

```
helm search repo diazoxide
NAME                    CHART VERSION   APP VERSION     DESCRIPTION                                       
diazoxide/external-dns  6.13.4          0.13.2          ExternalDNS is a Kubernetes addon that configur...
diazoxide/postgresql    12.1.15         15.2.0          PostgreSQL (Postgres) is an open source object-...
diazoxide/redis         20.3.0          7.4.1           Redis(R) is an open source, advanced key-value ...
diazoxide/symfony       1.2.0           1.2.0           Symfony Helm Chart for Kubernetes                 
```